### PR TITLE
fix: OAuthセッション期限切れを401で返し、画面描画時に検出する

### DIFF
--- a/app/api/bluesky/check/route.ts
+++ b/app/api/bluesky/check/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createOAuthAgent, OAuthSessionExpiredError } from "@/lib/oauth-client";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  try {
+    const sessionCookie = request.cookies.get("bsky_session")?.value;
+    if (!sessionCookie) {
+      return NextResponse.json({ error: "No session" }, { status: 401 });
+    }
+
+    const sessionData = JSON.parse(sessionCookie) as {
+      accessJwt?: string;
+      did?: string;
+    };
+
+    // Non-OAuth sessions don't need this check
+    if (!sessionData.accessJwt?.startsWith("oauth:")) {
+      return NextResponse.json({ valid: true });
+    }
+
+    const oauthDid =
+      sessionData.did ||
+      sessionData.accessJwt.slice("oauth:".length).trim();
+
+    await createOAuthAgent(oauthDid);
+    return NextResponse.json({ valid: true });
+  } catch (error) {
+    if (error instanceof OAuthSessionExpiredError) {
+      return NextResponse.json({ error: "Session expired" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "Session check failed" }, { status: 401 });
+  }
+}

--- a/app/api/bluesky/log/route.ts
+++ b/app/api/bluesky/log/route.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_BSKY_SERVICE,
   refreshSession,
 } from "@/lib/bluesky";
-import { createOAuthAgent, getOAuthStoredTokens } from "@/lib/oauth-client";
+import { createOAuthAgent, getOAuthStoredTokens, OAuthSessionExpiredError } from "@/lib/oauth-client";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -134,7 +134,17 @@ export async function POST(request: NextRequest) {
 
     let agent: Agent;
     if (isOAuthSession) {
-      agent = await createOAuthAgent(jwtDid);
+      try {
+        agent = await createOAuthAgent(jwtDid);
+      } catch (error) {
+        if (error instanceof OAuthSessionExpiredError) {
+          return NextResponse.json(
+            { error: "Session has expired. Please log in again." },
+            { status: 401 }
+          );
+        }
+        throw error;
+      }
     } else {
       const credentialAgent = createAgent(service ?? DEFAULT_BSKY_SERVICE);
       await credentialAgent.resumeSession({

--- a/app/components/LogComposer.tsx
+++ b/app/components/LogComposer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { FormEvent } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import BlueskyLink from "./BlueskyLink";
 import type { BlueskySession, Book, ReadingStatus } from "@/lib/types";
@@ -31,6 +31,22 @@ export default function LogComposer({ session }: LogComposerProps) {
   const [isPosting, setIsPosting] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [postedLogUrl, setPostedLogUrl] = useState<string | null>(null);
+
+  // OAuthセッションの有効性をマウント時に確認する
+  useEffect(() => {
+    if (!session?.accessJwt.startsWith("oauth:")) return;
+
+    let cancelled = false;
+    fetch("/api/bluesky/check").then((res) => {
+      if (!res.ok && !cancelled) {
+        window.dispatchEvent(new Event("library-sky-session-expired"));
+      }
+    }).catch(() => { /* ネットワークエラーは無視 */ });
+
+    return () => { cancelled = true; };
+  // sessionのDIDが変わったときだけ再チェック
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session?.did]);
 
   const handleSearch = async () => {
     if (!title.trim()) {

--- a/lib/oauth-client.ts
+++ b/lib/oauth-client.ts
@@ -7,7 +7,12 @@ import {
 } from "@atproto/oauth-client-node";
 import { Agent } from "@atproto/api";
 
-// Use globalThis to persist stores across Next.js hot reloads in dev mode
+// Use globalThis to persist stores across Next.js hot reloads in dev mode.
+// Note: on serverless platforms (e.g. Netlify), each function invocation may
+// be a fresh process, so sessions stored here will not survive between
+// cold-start invocations. When the session is gone, createOAuthAgent throws
+// OAuthSessionExpiredError and the API returns 401 so the client can prompt
+// the user to log in again.
 const globalStore = globalThis as unknown as {
   __oauthStateStore?: Map<string, NodeSavedState>;
   __oauthSessionStore?: Map<string, NodeSavedSession>;
@@ -58,10 +63,26 @@ export function getOAuthStoredTokens(sub: string): {
   };
 }
 
+export class OAuthSessionExpiredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OAuthSessionExpiredError";
+  }
+}
+
 export async function createOAuthAgent(sub: string): Promise<Agent> {
   const oauthClient = getOAuthClient();
-  const oauthSession = await oauthClient.restore(sub, "auto");
-  return new Agent(oauthSession);
+  try {
+    const oauthSession = await oauthClient.restore(sub, "auto");
+    return new Agent(oauthSession);
+  } catch (error) {
+    // Remove the stale session file so future logins start fresh
+    sessionStore.del(sub);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new OAuthSessionExpiredError(
+      `OAuth session expired or revoked: ${message}`
+    );
+  }
 }
 
 export function getOAuthClient(): NodeOAuthClient {


### PR DESCRIPTION
- lib/oauth-client.ts: createOAuthAgentのエラーをOAuthSessionExpiredErrorに変換し、失敗時にセッションを削除する
- app/api/bluesky/log/route.ts: OAuthSessionExpiredError時に500ではなく401を返す
- app/api/bluesky/check/route.ts: OAuthセッション有効性確認エンドポイントを追加
- app/components/LogComposer.tsx: マウント時にセッションチェックを行い、期限切れならlibrary-sky-session-expiredを発火する