### PR TITLE
feat: improve Bluesky image quality with book cover design

### DIFF
--- a/app/api/bluesky/log/route.ts
+++ b/app/api/bluesky/log/route.ts
@@ -7,6 +7,7 @@ import {
   refreshSession,
 } from "@/lib/bluesky";
 import { createOAuthAgent, getOAuthStoredTokens, OAuthSessionExpiredError } from "@/lib/oauth-client";
+import { processBookImageForBluesky } from "@/lib/image-processor";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -168,9 +169,19 @@ export async function POST(request: NextRequest) {
           const contentType = imageResponse.headers.get("content-type") ?? "";
           if (contentType.startsWith("image/")) {
             const imageBuffer = await imageResponse.arrayBuffer();
-            const uploaded = await agent.uploadBlob(new Uint8Array(imageBuffer), {
-              encoding: contentType,
-            });
+            
+            // Process the book image: add background and optimize quality
+            const processedImage = await processBookImageForBluesky(
+              Buffer.from(imageBuffer),
+              contentType
+            );
+            
+            const uploaded = await agent.uploadBlob(
+              new Uint8Array(processedImage.buffer),
+              {
+                encoding: processedImage.contentType,
+              }
+            );
             imageBlob = uploaded.data.blob;
           }
         }

--- a/lib/image-processor.ts
+++ b/lib/image-processor.ts
@@ -1,0 +1,75 @@
+"use server";
+
+import sharp from "sharp";
+
+export interface ProcessedImageBuffer {
+  buffer: Buffer;
+  width: number;
+  height: number;
+  contentType: string;
+}
+
+/**
+ * Process book cover image for Bluesky posting
+ * - Resize book cover to fit in a nice design
+ * - Add background aesthetic
+ * - Optimize for quality and file size
+ */
+export async function processBookImageForBluesky(
+  imageBuffer: Buffer,
+  contentType: string
+): Promise<ProcessedImageBuffer> {
+  try {
+    // Book cover dimensions (typical 2:3 aspect ratio)
+    const bookCoverWidth = 400;
+    const bookCoverHeight = 600;
+
+    // Final image dimensions with background
+    const finalWidth = 600;
+    const finalHeight = 900;
+
+    // Process book cover first
+    const processedBook = await sharp(imageBuffer)
+      .resize(bookCoverWidth, bookCoverHeight, {
+        fit: "cover",
+        position: "center",
+      })
+      .toBuffer();
+
+    // Create composite image with background
+    // Use stone background color (#3d3425) for a book-like aesthetic
+    const compositeBuffer = await sharp({
+      create: {
+        width: finalWidth,
+        height: finalHeight,
+        channels: 3,
+        background: { r: 61, g: 52, b: 37 }, // Stone/book color
+      },
+    })
+      .composite([
+        {
+          input: processedBook,
+          top: Math.floor((finalHeight - bookCoverHeight) / 2),
+          left: Math.floor((finalWidth - bookCoverWidth) / 2),
+        },
+      ])
+      .png({ quality: 95 })
+      .toBuffer();
+
+    return {
+      buffer: compositeBuffer,
+      width: finalWidth,
+      height: finalHeight,
+      contentType: "image/png",
+    };
+  } catch (error) {
+    console.error("Failed to process book image:", error);
+    // Return original image if processing fails
+    return {
+      buffer: imageBuffer,
+      width: 0,
+      height: 0,
+      contentType: contentType,
+    };
+  }
+}


### PR DESCRIPTION
- Add lib/image-processor.ts for processing book cover images
- Resize book covers to 400x600 and add stone-colored background (600x900 final)
- Use high-quality PNG compression (quality 95)
- Composite background under book for better aesthetic on Bluesky posts
- Update /api/bluesky/log to use new image processing

This improves the visual presentation of book covers on Bluesky posts and provides better image quality for users viewing the posts.